### PR TITLE
Enable Tailwind Preflight

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@broadlume/willow-ui",
   "main": "./src/index.ts",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "author": {
     "name": "dreadhalor",
     "url": "https://scotthetrick.com"

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,5 +1,3 @@
-@import '../src/assets/custom-preflight';
-@import '../src/assets/custom-preflight-2';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -72,9 +72,6 @@ export const themeColors = {
 export default {
   content: ['./src/**/*.{js,ts,jsx,tsx}'],
   prefix: '~',
-  corePlugins: {
-    preflight: false,
-  },
   theme: {
     container: {
       center: true,


### PR DESCRIPTION
"This PR enables preflight in Tailwind and removes the custom preflight CSS. I'm not sure why that was there—in theory, we shouldn't need it. It might have been added to handle some edge cases?