### PR TITLE
Fix react imports

### DIFF
--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { CaretSortIcon } from '@radix-ui/react-icons';
 
 import { cn, generateUntypeableId } from '@src/lib/utils';

--- a/src/components/command/command.tsx
+++ b/src/components/command/command.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { type DialogProps } from '@radix-ui/react-dialog';
 import { MagnifyingGlassIcon } from '@radix-ui/react-icons';
 import { Command as CommandPrimitive } from 'carloslfu-cmdk-internal';

--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import * as LabelPrimitive from '@radix-ui/react-label';
 import { Slot } from '@radix-ui/react-slot';
 import {

--- a/src/components/sheet/sheet.tsx
+++ b/src/components/sheet/sheet.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import * as SheetPrimitive from '@radix-ui/react-dialog';
 import { Cross2Icon } from '@radix-ui/react-icons';
 import { cva, type VariantProps } from 'class-variance-authority';

--- a/src/examples/components/chat.tsx
+++ b/src/examples/components/chat.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { PaperPlaneIcon } from '@radix-ui/react-icons';
 
 import { cn, getRandomAvatar } from '@src/lib/utils';


### PR DESCRIPTION
This PR:
- Fixes react imports to not use `* as React` as this was breaking some stuff with module federation in the shell

I noticed this when trying to use the Combobox element in the shell