### PR TITLE
feat: pageSizeOptions, sticky header and empty message in tanstack table

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@broadlume/willow-ui",
   "main": "./src/index.ts",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "author": {
     "name": "dreadhalor",
     "url": "https://scotthetrick.com"

--- a/src/misc/tanstack-table/Table.tsx
+++ b/src/misc/tanstack-table/Table.tsx
@@ -77,6 +77,8 @@ export function useDataTable<TData, TValue>({
   handleRowClick: passedHandlerRowClick,
   includeLoading = false,
   enableSingleSelection = false,
+  emptyMessage,
+  pageSizeOptions,
 }: DataTableProps<TData, TValue>) {
   /**
    * Column Ordering
@@ -497,9 +499,10 @@ export function useDataTable<TData, TValue>({
         </div>
       ) : (
         <div
-          {...itemProps?.tableWrapper}
+          {...(({ enableStickyHeader, ...rest }) => rest)(itemProps?.tableWrapper || {})}
           className={clsx(
             '~rounded-md ~border',
+            itemProps?.tableWrapper?.enableStickyHeader && '~max-h-[65vh] ~min-h-[0px] ~overflow-y-auto',
             itemProps?.tableWrapper?.className
           )}
         >
@@ -517,7 +520,10 @@ export function useDataTable<TData, TValue>({
                 <TableHeader
                   data-testid='data-table-header'
                   {...itemProps?.tableHeader}
-                  className={clsx(itemProps?.tableHeader?.className)}
+                  className={clsx(
+                    itemProps?.tableWrapper?.enableStickyHeader && '~sticky ~top-0 ~z-20 ~bg-white',
+                    itemProps?.tableHeader?.className
+                  )}
                 >
                   {table.getHeaderGroups().map((headerGroup) => (
                     <TableRow
@@ -597,7 +603,7 @@ export function useDataTable<TData, TValue>({
                         itemProps?.tableCell?.className
                       )}
                     >
-                      There are no records to display
+                      {emptyMessage || 'There are no records to display'}
                     </TableCell>
                   </TableRow>
                 )}
@@ -727,7 +733,7 @@ export function useDataTable<TData, TValue>({
               <SelectValue />
             </SelectTrigger>
             <SelectContent data-testid='perpage-list'>
-              {[5, 10, 20, 50].map((opt) => (
+              {(pageSizeOptions || [5, 10, 20, 50]).map((opt) => (
                 <SelectItem
                   {...itemProps?.itemPerPage?.selectItem}
                   data-testid={`perpage-item-${opt}`}

--- a/src/misc/tanstack-table/TableComponents.tsx
+++ b/src/misc/tanstack-table/TableComponents.tsx
@@ -11,7 +11,7 @@ const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
-  <div className='~relative ~w-full ~overflow-auto'>
+  <div className='~relative ~w-full'>
     <table
       ref={ref}
       className={clsx('~w-full ~caption-bottom ~text-sm', className)}

--- a/src/misc/tanstack-table/tanstack-table.stories.tsx
+++ b/src/misc/tanstack-table/tanstack-table.stories.tsx
@@ -87,3 +87,123 @@ const TanstackTableWithSingleRowSelection = () => {
 export const WithSingleRowSelection: Story = {
   render: (args) => <TanstackTableWithSingleRowSelection />,
 };
+
+// Story for DataTable with custom empty message
+const TanstackTableWithEmptyMessage = () => {
+  const { CustomDataTable, table } = useDataTable({
+    columns: columns,
+    data: [], // Empty data to trigger empty state
+    tableParams: {
+      manualPagination: false,
+    },
+    enableRowSelection: true,
+    emptyMessage: 'Custom empty message: No data found!',
+    includeLoading: false,
+  });
+  return <CustomDataTable />;
+};
+
+export const EmptyMessage: Story = {
+  render: (args) => <TanstackTableWithEmptyMessage />,
+};
+
+// Story for DataTable with JSX empty message
+const TanstackTableWithJSXEmptyMessage = () => {
+  const { CustomDataTable, table } = useDataTable({
+    columns: columns,
+    data: [], // Empty data to trigger empty state
+    tableParams: {
+      manualPagination: false,
+    },
+    enableRowSelection: true,
+    emptyMessage: (
+      <div className="~text-center ~py-8">
+        <h3 className="~text-lg ~font-semibold ~text-gray-700">No Data Available</h3>
+        <p className="~text-sm ~text-gray-500 ~mt-2">Try adjusting your filters or check back later.</p>
+      </div>
+    ),
+    includeLoading: false,
+  });
+  return <CustomDataTable />;
+};
+
+export const JSXEmptyMessage: Story = {
+  render: (args) => <TanstackTableWithJSXEmptyMessage />,
+};
+
+// Story for DataTable with dynamic background row colors
+const TanstackTableWithDynamicRowColors = () => {
+  const { CustomDataTable, table } = useDataTable({
+    columns: columns,
+    data: payments,
+    tableParams: {
+      manualPagination: false,
+    },
+    enableRowSelection: true,
+    itemProps: {
+      tableBodyRow: (row) => ({
+        className: row.original.status === 'success' 
+          ? '~bg-green-50 hover:~bg-green-100' 
+          : row.original.status === 'failed'
+          ? '~bg-red-50 hover:~bg-red-100'
+          : row.original.status === 'processing'
+          ? '~bg-blue-50 hover:~bg-blue-100'
+          : row.original.status === 'pending'
+          ? '~bg-yellow-50 hover:~bg-yellow-100'
+          : '~bg-gray-50 hover:~bg-gray-100'
+      })
+    }
+  });
+  return <CustomDataTable />;
+};
+
+export const DynamicRowColors: Story = {
+  render: (args) => <TanstackTableWithDynamicRowColors />,
+};
+
+// Story for DataTable with static background row colors
+const TanstackTableWithStaticRowColors = () => {
+  const { CustomDataTable, table } = useDataTable({
+    columns: columns,
+    data: payments,
+    tableParams: {
+      manualPagination: false,
+    },
+    enableRowSelection: true,
+    itemProps: {
+      tableBodyRow: {
+        className: '~bg-blue-50 hover:~bg-blue-100'
+      }
+    }
+  });
+  return <CustomDataTable />;
+};
+
+export const StaticRowColors: Story = {
+  render: (args) => <TanstackTableWithStaticRowColors />,
+};
+
+// Story for DataTable with sticky header and custom page size options
+const TanstackTableWithStickyHeaderAndCustomPageSizes = () => {
+  const { CustomDataTable, table } = useDataTable({
+    columns: columns,
+    data: payments,
+    tableParams: {
+      manualPagination: false,
+    },
+    enableRowSelection: true,
+    initialPagination: { pageIndex: 0, pageSize: 50 }, // Initial page size
+    pageSizeOptions: [10, 25, 50, 100, 250, 500, 1000], // Custom page size options
+    itemProps: {
+      tableWrapper: {
+        enableStickyHeader: true // Enable sticky header with scrollable body
+      }
+    },
+  });
+  return <CustomDataTable />;
+};
+
+export const StickyHeaderWithCustomPageSizes: Story = {
+  render: (args) => <TanstackTableWithStickyHeaderAndCustomPageSizes />,
+};
+

--- a/src/misc/tanstack-table/type.ts
+++ b/src/misc/tanstack-table/type.ts
@@ -43,6 +43,8 @@ export interface DataTableProps<TData, TValue> {
   enableSelectAllPages?: boolean;
   enableRowSelection?: boolean;
   enableSingleSelection?: boolean;
+  pageSizeOptions?: number[];
+  emptyMessage?: React.ReactNode;
   customTableRow?: (
     props: React.PropsWithChildren<
       { row: Row<TData> } & Parameters<typeof TableRow>[0]
@@ -55,7 +57,9 @@ export interface DataTableProps<TData, TValue> {
   }) => void;
   itemProps?: {
     root?: DataProps;
-    tableWrapper?: DataProps;
+    tableWrapper?: DataProps & {
+      enableStickyHeader?: boolean;
+    };
     table?: DataProps;
     tableHeader?: DataProps;
     tableHeaderRow?: DataProps;


### PR DESCRIPTION
- pageSizeOptions – Adds options to choose how many rows are displayed per page.
- Sticky Header – Keeps table headers visible while scrolling.
- Empty Message – Shows a custom message when no data is available.
**- All examples have been added in tanstack-table.stories.tsx.**









Ask ChatGPT









Ask ChatGPT
