### PR TITLE
Added copy-button & form-helper text from shell frontend to here

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@broadlume/willow-ui",
   "main": "./src/index.ts",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": {
     "name": "dreadhalor",
     "url": "https://scotthetrick.com"

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,5 +48,13 @@ export * from '@components/sidebar/sidebar';
 // Other stuff
 export * from '@src/lib/icons';
 export * from '@src/reports/summary-tile/summary-tile';
+
+export * from '@src/misc/copy-button/copy-button';
+
 export * from '@src/misc/custom-data-table/custom-data-table';
+export * from '@src/misc/custom-data-table/helpers/data-table-action-button';
+export * from '@src/misc/custom-data-table/helpers/data-table-limit-tooltip';
+
+export * from '@src/misc/form-helper-text/form-helper-text';
+
 export * from '@src/misc/tanstack-table/Table';

--- a/src/misc/copy-button/copy-button.stories.tsx
+++ b/src/misc/copy-button/copy-button.stories.tsx
@@ -1,0 +1,19 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { CopyButton } from './copy-button';
+
+const meta: Meta<typeof CopyButton> = {
+  title: 'Misc/Copy Button',
+  component: CopyButton,
+  args: {
+    value: 'Copy this text',
+  },
+  parameters: {
+    controls: { expanded: true },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CopyButton>;
+
+export const Default: Story = {};

--- a/src/misc/copy-button/copy-button.tsx
+++ b/src/misc/copy-button/copy-button.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { FaRegCopy } from 'react-icons/fa';
+import { Button } from '../../components/button';
+
+interface CopyButtonProps {
+  value: string;
+}
+
+/** A button that copies the provided value to the clipboard */
+const CopyButton: React.FC<CopyButtonProps> = ({ value }) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(value);
+    setCopied(true);
+    setTimeout(() => {
+      setCopied(false);
+    }, 2000); // Message visible for 2 seconds
+  };
+
+  return (
+    <Button onClick={handleCopy} variant='ghost' size='sm'>
+      <span className='mr-2 font-normal normal-case'>
+        {copied ? 'Copied to clipboard!' : value}
+      </span>
+      <FaRegCopy />
+    </Button>
+  );
+};
+
+export { CopyButton };

--- a/src/misc/form-helper-text/form-helper-text.stories.tsx
+++ b/src/misc/form-helper-text/form-helper-text.stories.tsx
@@ -1,0 +1,19 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { FormHelperText } from './form-helper-text';
+
+const meta: Meta<typeof FormHelperText> = {
+  title: 'Misc/Form Helper Text',
+  component: FormHelperText,
+  args: {
+    text: 'This is some helper text.',
+  },
+  parameters: {
+    controls: { expanded: true },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof FormHelperText>;
+
+export const Default: Story = {};

--- a/src/misc/form-helper-text/form-helper-text.tsx
+++ b/src/misc/form-helper-text/form-helper-text.tsx
@@ -1,0 +1,10 @@
+/** Just a simple component to be used in forms to display helper text */
+const FormHelperText = (props: { text: string }) => {
+  return (
+    <span className='text-sm font-small italic leading-none text-muted-foreground '>
+      {props.text}
+    </span>
+  );
+};
+
+export { FormHelperText };


### PR DESCRIPTION
Moved the components here so that we can remove shell component dependancies in catalog

Also exposed some of the data-table helpers as they were not exported