### PR TITLE
feat(editor): add advancedOptions with hide flags for Image, Video, Table, Link, and Raw HTML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@broadlume/willow-ui",
-  "version": "1.0.66",
+  "version": "1.0.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@broadlume/willow-ui",
-      "version": "1.0.66",
+      "version": "1.0.68",
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.7.4",
         "@atlaskit/pragmatic-drag-and-drop-react-drop-indicator": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@broadlume/willow-ui",
   "main": "./src/index.ts",
-  "version": "1.0.67",
+  "version": "1.0.68",
   "author": {
     "name": "dreadhalor",
     "url": "https://scotthetrick.com"

--- a/src/components/editor/components/menu.tsx
+++ b/src/components/editor/components/menu.tsx
@@ -53,19 +53,19 @@ interface MenuProps {
   onAssetSelectorChange?: (editor: Editor, value: File | string | null) => void; // Callback when MiniAssetSelector value changes
   assetSelectorValue?: string; // Controlled value for the MiniAssetSelector input in the image insertion dialog
   onAssetSelectorValueChange?: (value: string) => void; // Callback when the MiniAssetSelector input value changes
+  hideAIMenu?: boolean; // Whether to hide the AI Menu (slash command menu)
+  isShowAssetBrowseButton?: boolean; // Whether to show the browse button in the asset selector
+  isShowAssetEditIcon?: boolean; // Whether to show edit icon on image preview
+  disableAssetImageNameClick?: boolean; // Whether to disable clicking on the image name - independent from the disabled prop
   authToken?: string; // Bearer token for AI API authorization
 }
 
 const DEFAULT_ADVANCED_OPTIONS: Required<EditorAdvancedOptions> = {
-  hideAIMenu: false,
   hideImageOption: false,
   hideVideoOption: false,
   hideTableOption: false,
   hideLinkOption: false,
   hideToggleRawHtmlOption: false,
-  isShowAssetBrowseButton: true,
-  isShowAssetEditIcon: false,
-  disableAssetImageNameClick: false,
 };
 
 type L2MenuType = 'video' | 'embed' | 'link' | 'image';
@@ -92,6 +92,10 @@ export const Menu = ({
   onAssetSelectorChange,
   assetSelectorValue,
   onAssetSelectorValueChange,
+  hideAIMenu,
+  isShowAssetBrowseButton = true,
+  isShowAssetEditIcon,
+  disableAssetImageNameClick,
   authToken,
 }: MenuProps) => {
   const options: Required<EditorAdvancedOptions> = {
@@ -199,7 +203,7 @@ export const Menu = ({
 
     // Iterate through all menu items and decide where to place them
     const allMenuItems = getAllMenuItems().filter((item) => {
-      if (options.hideAIMenu && item.id === 'ai-button') return false;
+      if (hideAIMenu && item.id === 'ai-button') return false;
       if (options.hideImageOption && item.id === 'image') return false;
       if (options.hideVideoOption && item.id === 'video') return false;
       if (options.hideTableOption && item.id === 'table') return false;
@@ -243,7 +247,7 @@ export const Menu = ({
     setHiddenItems(tempHidden);
   }, [
     availableWidth,
-    options.hideAIMenu,
+    hideAIMenu,
     options.hideImageOption,
     options.hideVideoOption,
     options.hideTableOption,
@@ -273,14 +277,14 @@ export const Menu = ({
     onImageBrowseClick,
     onImageDrop,
     onImageNameClick,
-    disableAssetImageNameClick: options.disableAssetImageNameClick,
-    isShowAssetEditIcon: options.isShowAssetEditIcon,
+    disableAssetImageNameClick,
+    isShowAssetEditIcon,
     onAssetSelectorChange,
     expandedMenu,
     setExpandedMenu,
     expandedMenuL2,
     setExpandedMenuL2,
-    isShowAssetBrowseButton: options.isShowAssetBrowseButton,
+    isShowAssetBrowseButton,
     authToken,
   };
 
@@ -401,10 +405,10 @@ export const Menu = ({
           onImageBrowseClick,
           onImageDrop,
           onImageNameClick,
-          options.disableAssetImageNameClick,
-          options.isShowAssetEditIcon,
+          disableAssetImageNameClick,
+          isShowAssetEditIcon,
           onAssetSelectorChange,
-          options.isShowAssetBrowseButton
+          isShowAssetBrowseButton
         )}
       </div>
       {/* Expanded Menu L2*/}

--- a/src/components/editor/components/menu.tsx
+++ b/src/components/editor/components/menu.tsx
@@ -53,7 +53,7 @@ interface MenuProps {
   onAssetSelectorChange?: (editor: Editor, value: File | string | null) => void; // Callback when MiniAssetSelector value changes
   assetSelectorValue?: string; // Controlled value for the MiniAssetSelector input in the image insertion dialog
   onAssetSelectorValueChange?: (value: string) => void; // Callback when the MiniAssetSelector input value changes
-  hideAIMenu?: boolean; // // Whether to hide the AI Menu
+  hideAIMenu?: boolean; // Whether to hide the AI Menu
   isShowAssetBrowseButton?: boolean; // Whether to show the browse button in the asset selector
   isShowAssetEditIcon?: boolean; // Whether to show edit icon on image preview
   disableAssetImageNameClick?: boolean; // Whether to disable clicking on the image name - independent from the disabled prop

--- a/src/components/editor/components/menu.tsx
+++ b/src/components/editor/components/menu.tsx
@@ -53,7 +53,7 @@ interface MenuProps {
   onAssetSelectorChange?: (editor: Editor, value: File | string | null) => void; // Callback when MiniAssetSelector value changes
   assetSelectorValue?: string; // Controlled value for the MiniAssetSelector input in the image insertion dialog
   onAssetSelectorValueChange?: (value: string) => void; // Callback when the MiniAssetSelector input value changes
-  hideAIMenu?: boolean; // Whether to hide the AI Menu (slash command menu)
+  hideAIMenu?: boolean; // // Whether to hide the AI Menu
   isShowAssetBrowseButton?: boolean; // Whether to show the browse button in the asset selector
   isShowAssetEditIcon?: boolean; // Whether to show edit icon on image preview
   disableAssetImageNameClick?: boolean; // Whether to disable clicking on the image name - independent from the disabled prop
@@ -201,16 +201,22 @@ export const Menu = ({
     const tempVisible: MenuItemDefinition[] = [];
     const tempHidden: MenuItemDefinition[] = [];
 
-    // Iterate through all menu items and decide where to place them
-    const allMenuItems = getAllMenuItems().filter((item) => {
-      if (hideAIMenu && item.id === 'ai-button') return false;
-      if (options.hideImageOption && item.id === 'image') return false;
-      if (options.hideVideoOption && item.id === 'video') return false;
-      if (options.hideTableOption && item.id === 'table') return false;
-      if (options.hideLinkOption && item.id === 'link') return false;
-      if (options.hideToggleRawHtmlOption && item.id === 'code') return false;
-      return true;
-    });
+    const hideConfig: ReadonlyArray<[boolean | undefined, string]> = [
+      [hideAIMenu, 'ai-button'],
+      [options.hideImageOption, 'image'],
+      [options.hideVideoOption, 'video'],
+      [options.hideTableOption, 'table'],
+      [options.hideLinkOption, 'link'],
+      [options.hideToggleRawHtmlOption, 'code'],
+    ];
+
+    const hiddenItemIds = new Set(
+      hideConfig.filter(([condition]) => condition).map(([, id]) => id)
+    );
+
+    const allMenuItems = getAllMenuItems().filter(
+      (item) => !hiddenItemIds.has(item.id)
+    );
     for (const item of allMenuItems) {
       // Estimate item width, including a gap if it's not the first item
       const itemRenderedWidth = item.widthEstimate + GAP_WIDTH;

--- a/src/components/editor/components/menu.tsx
+++ b/src/components/editor/components/menu.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { Editor } from '@tiptap/react';
 import clsx from 'clsx';
+import type { EditorAdvancedOptions } from '../editor';
 
 // Icons
 import { MdOutlineMoreVert } from 'react-icons/md';
@@ -48,15 +49,24 @@ interface MenuProps {
       file: File | null;
     }
   ) => void; // Callback for when image name is clicked
-  disableAssetImageNameClick?: boolean; // Whether to disable clicking on the image name - independent from the disabled prop
-  isShowAssetEditIcon?: boolean; // Whether to show edit icon on image preview
+  advancedOptions?: EditorAdvancedOptions; // Advanced visibility/config options for menu actions
   onAssetSelectorChange?: (editor: Editor, value: File | string | null) => void; // Callback when MiniAssetSelector value changes
   assetSelectorValue?: string; // Controlled value for the MiniAssetSelector input in the image insertion dialog
   onAssetSelectorValueChange?: (value: string) => void; // Callback when the MiniAssetSelector input value changes
-  hideAIMenu?: boolean; // Whether to hide the AI Menu button,
-  isShowAssetBrowseButton?: boolean; // Whether to show the browse button in the asset selector
   authToken?: string; // Bearer token for AI API authorization
 }
+
+const DEFAULT_ADVANCED_OPTIONS: Required<EditorAdvancedOptions> = {
+  hideAIMenu: false,
+  hideImageOption: false,
+  hideVideoOption: false,
+  hideTableOption: false,
+  hideLinkOption: false,
+  hideToggleRawHtmlOption: false,
+  isShowAssetBrowseButton: true,
+  isShowAssetEditIcon: false,
+  disableAssetImageNameClick: false,
+};
 
 type L2MenuType = 'video' | 'embed' | 'link' | 'image';
 
@@ -78,15 +88,17 @@ export const Menu = ({
   onImageBrowseClick,
   onImageDrop,
   onImageNameClick,
-  disableAssetImageNameClick,
-  isShowAssetEditIcon,
+  advancedOptions,
   onAssetSelectorChange,
   assetSelectorValue,
   onAssetSelectorValueChange,
-  hideAIMenu,
-  isShowAssetBrowseButton = true,
   authToken,
 }: MenuProps) => {
+  const options: Required<EditorAdvancedOptions> = {
+    ...DEFAULT_ADVANCED_OPTIONS,
+    ...advancedOptions,
+  };
+
   const [expandedMenu, setExpandedMenu] = useState(false);
   const [expandedMenuL2, setExpandedMenuL2] = useState(false);
   const [expandedMenuL2Type, setExpandedMenuL2Type] = useState<L2MenuType>();
@@ -186,9 +198,15 @@ export const Menu = ({
     const tempHidden: MenuItemDefinition[] = [];
 
     // Iterate through all menu items and decide where to place them
-    const allMenuItems = getAllMenuItems().filter(
-      (item) => !(hideAIMenu && item.id === 'ai-button')
-    );
+    const allMenuItems = getAllMenuItems().filter((item) => {
+      if (options.hideAIMenu && item.id === 'ai-button') return false;
+      if (options.hideImageOption && item.id === 'image') return false;
+      if (options.hideVideoOption && item.id === 'video') return false;
+      if (options.hideTableOption && item.id === 'table') return false;
+      if (options.hideLinkOption && item.id === 'link') return false;
+      if (options.hideToggleRawHtmlOption && item.id === 'code') return false;
+      return true;
+    });
     for (const item of allMenuItems) {
       // Estimate item width, including a gap if it's not the first item
       const itemRenderedWidth = item.widthEstimate + GAP_WIDTH;
@@ -223,7 +241,15 @@ export const Menu = ({
 
     setVisibleItems(tempVisible);
     setHiddenItems(tempHidden);
-  }, [availableWidth, hideAIMenu]);
+  }, [
+    availableWidth,
+    options.hideAIMenu,
+    options.hideImageOption,
+    options.hideVideoOption,
+    options.hideTableOption,
+    options.hideLinkOption,
+    options.hideToggleRawHtmlOption,
+  ]);
 
   const commonMenuItemProps: MenuItemRenderProps = {
     editor,
@@ -247,14 +273,14 @@ export const Menu = ({
     onImageBrowseClick,
     onImageDrop,
     onImageNameClick,
-    disableAssetImageNameClick,
-    isShowAssetEditIcon,
+    disableAssetImageNameClick: options.disableAssetImageNameClick,
+    isShowAssetEditIcon: options.isShowAssetEditIcon,
     onAssetSelectorChange,
     expandedMenu,
     setExpandedMenu,
     expandedMenuL2,
     setExpandedMenuL2,
-    isShowAssetBrowseButton,
+    isShowAssetBrowseButton: options.isShowAssetBrowseButton,
     authToken,
   };
 
@@ -375,10 +401,10 @@ export const Menu = ({
           onImageBrowseClick,
           onImageDrop,
           onImageNameClick,
-          disableAssetImageNameClick,
-          isShowAssetEditIcon,
+          options.disableAssetImageNameClick,
+          options.isShowAssetEditIcon,
           onAssetSelectorChange,
-          isShowAssetBrowseButton
+          options.isShowAssetBrowseButton
         )}
       </div>
       {/* Expanded Menu L2*/}

--- a/src/components/editor/editor.stories.tsx
+++ b/src/components/editor/editor.stories.tsx
@@ -57,10 +57,8 @@ const EditorComponentWithoutAI = () => {
       onBlur={(html) => console.log('Content blurred:', html)}
       autocompleteFetchOptions={fetchUsersFromApi}
       hostname='https://api.cms.my.dev.broadlume.com'
-      advancedOptions={{
-        hideAIMenu: true,
-        isShowAssetBrowseButton: false,
-      }}
+      hideAIMenu={true}
+      isShowAssetBrowseButton={false}
     />
   );
 };
@@ -88,9 +86,9 @@ const EditorComponentWithoutAdvancedOption = () => {
       onBlur={(html) => console.log('Content blurred:', html)}
       autocompleteFetchOptions={fetchUsersFromApi}
       hostname='https://api.cms.my.dev.broadlume.com'
+      hideAIMenu={true}
+      isShowAssetBrowseButton={false}
       advancedOptions={{
-        hideAIMenu: true,
-        isShowAssetBrowseButton: false,
         hideImageOption: true,
         hideVideoOption: true,
         hideTableOption: true,

--- a/src/components/editor/editor.stories.tsx
+++ b/src/components/editor/editor.stories.tsx
@@ -68,23 +68,11 @@ export const WithoutAIMenu: Story = {
 };
 
 const EditorComponentWithoutAdvancedOption = () => {
-  const fetchUsersFromApi = useCallback(async (query: string) => {
-    const users = [
-      { id: '1', name: 'John Doe' },
-      { id: '2', name: 'Jane Smith' },
-      { id: '3', name: 'Peter Jones' },
-    ];
-    await new Promise((resolve) => setTimeout(resolve, 300));
-    return users
-      .filter((user) => user.name.toLowerCase().includes(query.toLowerCase()))
-      .map((user) => ({ label: user.name, value: user.id }));
-  }, []);
 
   return (
     <Editor
       onChange={(html) => console.log('Content changed:', html)}
       onBlur={(html) => console.log('Content blurred:', html)}
-      autocompleteFetchOptions={fetchUsersFromApi}
       hostname='https://api.cms.my.dev.broadlume.com'
       hideAIMenu={true}
       isShowAssetBrowseButton={false}

--- a/src/components/editor/editor.stories.tsx
+++ b/src/components/editor/editor.stories.tsx
@@ -57,12 +57,50 @@ const EditorComponentWithoutAI = () => {
       onBlur={(html) => console.log('Content blurred:', html)}
       autocompleteFetchOptions={fetchUsersFromApi}
       hostname='https://api.cms.my.dev.broadlume.com'
-      hideAIMenu={true}
-      isShowAssetBrowseButton={false}
+      advancedOptions={{
+        hideAIMenu: true,
+        isShowAssetBrowseButton: false,
+      }}
     />
   );
 };
 
 export const WithoutAIMenu: Story = {
-  render: () => <EditorComponentWithoutAI />,
+  render: () => <EditorComponentWithoutAI />
+};
+
+const EditorComponentWithoutAdvancedOption = () => {
+  const fetchUsersFromApi = useCallback(async (query: string) => {
+    const users = [
+      { id: '1', name: 'John Doe' },
+      { id: '2', name: 'Jane Smith' },
+      { id: '3', name: 'Peter Jones' },
+    ];
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    return users
+      .filter((user) => user.name.toLowerCase().includes(query.toLowerCase()))
+      .map((user) => ({ label: user.name, value: user.id }));
+  }, []);
+
+  return (
+    <Editor
+      onChange={(html) => console.log('Content changed:', html)}
+      onBlur={(html) => console.log('Content blurred:', html)}
+      autocompleteFetchOptions={fetchUsersFromApi}
+      hostname='https://api.cms.my.dev.broadlume.com'
+      advancedOptions={{
+        hideAIMenu: true,
+        isShowAssetBrowseButton: false,
+        hideImageOption: true,
+        hideVideoOption: true,
+        hideTableOption: true,
+        hideLinkOption: true,
+        hideToggleRawHtmlOption: true,
+      }}
+    />
+  );
+};
+
+export const EditorWithoutAdvancedOption: Story = {
+  render: () => <EditorComponentWithoutAdvancedOption />
 };

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -45,15 +45,11 @@ import { EditorContent } from './components/editor-content';
 import { SlashCommand } from './extensions/slash-command';
 
 export type EditorAdvancedOptions = {
-  hideAIMenu?: boolean; // Whether to hide the AI Menu (slash command menu)
   hideImageOption?: boolean; // Whether to hide the Insert Image toolbar option
   hideVideoOption?: boolean; // Whether to hide the Insert Video toolbar option
   hideTableOption?: boolean; // Whether to hide the Insert Table toolbar option
   hideLinkOption?: boolean; // Whether to hide the Add Link toolbar option
   hideToggleRawHtmlOption?: boolean; // Whether to hide the Toggle Code/Raw HTML toolbar option
-  isShowAssetBrowseButton?: boolean; // Whether to show the browse button in the asset selector
-  isShowAssetEditIcon?: boolean; // Whether to show edit icon on image preview
-  disableAssetImageNameClick?: boolean; // Whether to disable clicking on the image name
 };
 
 export type EditorProps = {
@@ -87,12 +83,16 @@ export type EditorProps = {
       file: File | null;
     }
   ) => void; // Callback for when image name is clicked
+  disableAssetImageNameClick?: boolean; // Whether to disable clicking on the image name - independent from the disabled prop
+  isShowAssetEditIcon?: boolean; // Whether to show edit icon on image preview
   onAssetSelectorChange?: (
     editor: TiptapEditor,
     value: File | string | null
   ) => void; // Callback when MiniAssetSelector value changes
   assetSelectorValue?: string; // Controlled value for the MiniAssetSelector input in the image insertion dialog
   onAssetSelectorValueChange?: (value: string) => void; // Callback when the MiniAssetSelector input value changes
+  hideAIMenu?: boolean; // Whether to hide the AI Menu (slash command menu)
+  isShowAssetBrowseButton?: boolean; // Whether to show the browse button in the asset selector
   advancedOptions?: EditorAdvancedOptions; // Optional object to configure visibility of toolbar items
   authToken?: string; // Bearer token for AI API authorization
 };
@@ -293,10 +293,14 @@ export const Editor: React.FC<EditorProps> = (props) => {
                 onImageBrowseClick={props.onImageBrowseClick}
                 onImageDrop={props.onImageDrop}
                 onImageNameClick={props.onImageNameClick}
+                disableAssetImageNameClick={props.disableAssetImageNameClick}
+                isShowAssetEditIcon={props.isShowAssetEditIcon}
                 advancedOptions={props.advancedOptions}
                 onAssetSelectorChange={props.onAssetSelectorChange}
                 assetSelectorValue={props.assetSelectorValue}
                 onAssetSelectorValueChange={props.onAssetSelectorValueChange}
+                hideAIMenu={props.hideAIMenu}
+                isShowAssetBrowseButton={props.isShowAssetBrowseButton}
                 className={clsx({
                   'bg-gray-100': !darkMode,
                   'text-gray-800': !darkMode,
@@ -332,10 +336,14 @@ export const Editor: React.FC<EditorProps> = (props) => {
               onImageBrowseClick={props.onImageBrowseClick}
               onImageDrop={props.onImageDrop}
               onImageNameClick={props.onImageNameClick}
+              disableAssetImageNameClick={props.disableAssetImageNameClick}
+              isShowAssetEditIcon={props.isShowAssetEditIcon}
               advancedOptions={props.advancedOptions}
               onAssetSelectorChange={props.onAssetSelectorChange}
               assetSelectorValue={props.assetSelectorValue}
               onAssetSelectorValueChange={props.onAssetSelectorValueChange}
+              hideAIMenu={props.hideAIMenu}
+              isShowAssetBrowseButton={props.isShowAssetBrowseButton}
               className={clsx({
                 'bg-surface-pri text-text-pri': !darkMode,
                 'border-gray-700 bg-gray-900 text-white': darkMode,

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -44,6 +44,18 @@ import { Menu } from './components/menu';
 import { EditorContent } from './components/editor-content';
 import { SlashCommand } from './extensions/slash-command';
 
+export type EditorAdvancedOptions = {
+  hideAIMenu?: boolean; // Whether to hide the AI Menu (slash command menu)
+  hideImageOption?: boolean; // Whether to hide the Insert Image toolbar option
+  hideVideoOption?: boolean; // Whether to hide the Insert Video toolbar option
+  hideTableOption?: boolean; // Whether to hide the Insert Table toolbar option
+  hideLinkOption?: boolean; // Whether to hide the Add Link toolbar option
+  hideToggleRawHtmlOption?: boolean; // Whether to hide the Toggle Code/Raw HTML toolbar option
+  isShowAssetBrowseButton?: boolean; // Whether to show the browse button in the asset selector
+  isShowAssetEditIcon?: boolean; // Whether to show edit icon on image preview
+  disableAssetImageNameClick?: boolean; // Whether to disable clicking on the image name
+};
+
 export type EditorProps = {
   content?: string;
   onChange?: (html: string) => void;
@@ -75,16 +87,13 @@ export type EditorProps = {
       file: File | null;
     }
   ) => void; // Callback for when image name is clicked
-  disableAssetImageNameClick?: boolean; // Whether to disable clicking on the image name - independent from the disabled prop
-  isShowAssetEditIcon?: boolean; // Whether to show edit icon on image preview
   onAssetSelectorChange?: (
     editor: TiptapEditor,
     value: File | string | null
   ) => void; // Callback when MiniAssetSelector value changes
   assetSelectorValue?: string; // Controlled value for the MiniAssetSelector input in the image insertion dialog
   onAssetSelectorValueChange?: (value: string) => void; // Callback when the MiniAssetSelector input value changes
-  hideAIMenu?: boolean; // Whether to hide the AI Menu (slash command menu)
-  isShowAssetBrowseButton?: boolean; // Whether to show the browse button in the asset selector
+  advancedOptions?: EditorAdvancedOptions; // Optional object to configure visibility of toolbar items
   authToken?: string; // Bearer token for AI API authorization
 };
 
@@ -284,13 +293,10 @@ export const Editor: React.FC<EditorProps> = (props) => {
                 onImageBrowseClick={props.onImageBrowseClick}
                 onImageDrop={props.onImageDrop}
                 onImageNameClick={props.onImageNameClick}
-                disableAssetImageNameClick={props.disableAssetImageNameClick}
-                isShowAssetEditIcon={props.isShowAssetEditIcon}
+                advancedOptions={props.advancedOptions}
                 onAssetSelectorChange={props.onAssetSelectorChange}
                 assetSelectorValue={props.assetSelectorValue}
                 onAssetSelectorValueChange={props.onAssetSelectorValueChange}
-                hideAIMenu={props.hideAIMenu}
-                isShowAssetBrowseButton={props.isShowAssetBrowseButton}
                 className={clsx({
                   'bg-gray-100': !darkMode,
                   'text-gray-800': !darkMode,
@@ -326,13 +332,10 @@ export const Editor: React.FC<EditorProps> = (props) => {
               onImageBrowseClick={props.onImageBrowseClick}
               onImageDrop={props.onImageDrop}
               onImageNameClick={props.onImageNameClick}
-              disableAssetImageNameClick={props.disableAssetImageNameClick}
-              isShowAssetEditIcon={props.isShowAssetEditIcon}
+              advancedOptions={props.advancedOptions}
               onAssetSelectorChange={props.onAssetSelectorChange}
               assetSelectorValue={props.assetSelectorValue}
               onAssetSelectorValueChange={props.onAssetSelectorValueChange}
-              hideAIMenu={props.hideAIMenu}
-              isShowAssetBrowseButton={props.isShowAssetBrowseButton}
               className={clsx({
                 'bg-surface-pri text-text-pri': !darkMode,
                 'border-gray-700 bg-gray-900 text-white': darkMode,


### PR DESCRIPTION
feat(editor): add advancedOptions for toolbar visibility control

Added `EditorAdvancedOptions` object to Editor with 5 new hide flags. Existing props unchanged.

**New**
- `advancedOptions?: EditorAdvancedOptions` on `EditorProps`
- Fields: `hideImageOption`, `hideVideoOption`, `hideTableOption`, `hideLinkOption`, `hideToggleRawHtmlOption`
- Defaults via `DEFAULT_ADVANCED_OPTIONS` in Menu — existing behavior preserved

**Package version update:**

- Bumped the package version from 1.0.67 to 1.0.68 in package.json.
